### PR TITLE
fix README.md (no functional change)

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,17 +16,11 @@ I can't give a list of changes - it is just different.
 - F9 now drops only *material* items if the gnome has at least one such item in inventory. Otherwise, *everything* is dropped (like before).
 - Increased the range at which food items are considered to be *in* the kitchen from 7 to 10 (all three kitchens, but not the fire place).
 ## bugfixes
-- Fixed a bug where the barkeeper would get stuck when four orders are pending at the same time.
-- Fixed a bug where the first position of bowlers would become unusable in certain situations.
-- Fixed that other bowling guests can cheer or boo at the current bowler.
 - Fixed that if many items are already on the ground, a gnome might fail to put down another item.
 - Fixed what looks like a typo and should affect how gnomes decide they are done with their current spare-time activity.
 - Reduced the mood loss from bad sleep quality (insufficient beds) by half. The same code was in here twice, so it seems this was not intentional (and thus I consider it a bug).
-- Fixed a bug where gnomes could no longer use the disco and would leave immediately after arriving.
 - Fixed a bug where the hospital would no longer work after a patient died.
-- Workaround for when the bowling alley is stuck because the gnome registered as current bowler has left somehow.
 - Partially fixed the animation at the hospital where the patient should lay in bed: Now they are laying, but hovering a bit above the bed ...
-- Fixed a bug in the lava world where Fenris isn't found in his lair.
 ## known bugs
 - Production sites no longer show when a gnome is working (the small green progress indicator is missing). I have no clue how to fix this.
 ## unknown bugs

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ I can't give a list of changes - it is just different.
 - Partially fixed the animation at the hospital where the patient should lay in bed: Now they are laying, but hovering a bit above the bed ...
 ## known bugs
 - Production sites no longer show when a gnome is working (the small green progress indicator is missing). I have no clue how to fix this.
+- Energy production sites will no longer consume material (the sites still need to be present with their resources).
 ## unknown bugs
 - This mod was developed on the original CD version of the game from 2001, no idea if it works on the re-release on GoG/Steam.
 - Generally very little tested at all.
@@ -37,3 +38,4 @@ but it is currently nowhere publicly available. Also, the moment of transition w
 the same place, idle gnomes not working at all for a while (until manually moved around), and maybe other issues.
 ## Combination with other mods
 Untested, but I expect this to fail for a lot of other mods, since this mod has a lot of changes so that the probability of a conflict is high.
+This mod will not work in combination with "CommandF9", because both will change the behavior of the F9 key.

--- a/README.md
+++ b/README.md
@@ -5,6 +5,8 @@ While I was at it, I also fixed some bugs. And added new bugs.
 ## work-time assignments
 Due to technical limitations, the new scheduler for work is a completely new implementation, independent of the original one. Therefore 
 I can't give a list of changes - it is just different.
+## new feature
+Items very(!) close to a border stone will be carried "home", if the stone isn't already close
 ## spare-time activities
 - Increased search range for a hospital from 40 units to 160 units.
 - Reduced the late-game needs for quality and variety of spare-time activities: At high "civilization states" the gnome's requirements were impossible to satisfy, resulting in significant mood losses.


### PR DESCRIPTION
All in README.md, doesn't change anything about the actual mod:
- Remove the description of bugfixes that had been moved to the BugFix mod a long time ago.
- Add description of another know (potentially unfixable) bug regarding energy production.
- Mention incompatibility with the "CommandF9" mod.
- Mention "border stone" feature.